### PR TITLE
update license year

### DIFF
--- a/example.cpp
+++ b/example.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/example.sh
+++ b/example.sh
@@ -1,4 +1,4 @@
-# Copyright 2014 Richard Pausch
+# Copyright 2014-2016 Richard Pausch
 #
 # This file is part of Clara 2.
 #

--- a/src/all_directions.cpp
+++ b/src/all_directions.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/all_directions.hpp
+++ b/src/all_directions.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/convert_to_matrix.cpp
+++ b/src/convert_to_matrix.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/gzip_lib.hpp
+++ b/src/gzip_lib.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/analytical_solution.hpp
+++ b/src/include/analytical_solution.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/detector_dft.cpp
+++ b/src/include/detector_dft.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/detector_dft.hpp
+++ b/src/include/detector_dft.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/detector_e_field.cpp
+++ b/src/include/detector_e_field.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/detector_e_field.hpp
+++ b/src/include/detector_e_field.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/detector_fft.cpp
+++ b/src/include/detector_fft.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/detector_fft.hpp
+++ b/src/include/detector_fft.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/discrete.hpp
+++ b/src/include/discrete.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/fft_ned.hpp
+++ b/src/include/fft_ned.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/import_from_file.hpp
+++ b/src/include/import_from_file.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/interpolation.hpp
+++ b/src/include/interpolation.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/interpolation.tpp
+++ b/src/include/interpolation.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/large_index_storage.hpp
+++ b/src/include/large_index_storage.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/large_index_storage.tpp
+++ b/src/include/large_index_storage.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/load_txt.hpp
+++ b/src/include/load_txt.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/makefile
+++ b/src/include/makefile
@@ -1,4 +1,4 @@
-# Copyright 2014 Richard Pausch
+# Copyright 2014-2016 Richard Pausch
 #
 # This file is part of Clara 2.
 #

--- a/src/include/physics_units.hpp
+++ b/src/include/physics_units.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/string_manipulation.hpp
+++ b/src/include/string_manipulation.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/utilities.hpp
+++ b/src/include/utilities.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/vector.hpp
+++ b/src/include/vector.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/include/vector.tpp
+++ b/src/include/vector.tpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/makefile
+++ b/src/makefile
@@ -1,4 +1,4 @@
-# Copyright 2014 Richard Pausch
+# Copyright 2014-2016 Richard Pausch
 #
 # This file is part of Clara 2.
 #

--- a/src/parallel_jobs.h
+++ b/src/parallel_jobs.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/prepare_job.sh
+++ b/src/prepare_job.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014 Richard Pausch
+# Copyright 2014-2016 Richard Pausch
 #
 # This file is part of Clara 2.
 #

--- a/src/process_data.cpp
+++ b/src/process_data.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/run_through_data.hpp
+++ b/src/run_through_data.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/single_trace.cpp
+++ b/src/single_trace.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/src/single_trace.hpp
+++ b/src/single_trace.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Richard Pausch
+ * Copyright 2014-2016 Richard Pausch
  *
  * This file is part of Clara 2.
  *

--- a/tools/plotRadiation
+++ b/tools/plotRadiation
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2013-2014 Richard Pausch
+# Copyright 2013-2016 Richard Pausch
 #
 # This file is part of PIConGPU and clara2.
 #

--- a/tools/smooth.py
+++ b/tools/smooth.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014 Richard Pausch
+# Copyright 2013-2016 Richard Pausch
 #
 # This file is part of PIConGPU and clara2.
 #


### PR DESCRIPTION
This pull request brings the license header of Clara2 up to date. Now it has a copyright of 2016. 
