### PR TITLE
adjust DFT detector interface

### DIFF
--- a/src/include/detector_dft.cpp
+++ b/src/include/detector_dft.cpp
@@ -25,9 +25,9 @@
 
 // Constructors and Destructors:
 
-Detector_dft::Detector_dft(R_vec n_unit, double delta_t, const unsigned spek_length,
+Detector_dft::Detector_dft(R_vec n_unit, const unsigned spek_length,
 			   const double omega_max)
-  : n_unit(n_unit.unit_vec()), delta_t(delta_t), spek_length(spek_length),
+  : n_unit(n_unit.unit_vec()),  spek_length(spek_length),
     spektrum(0), spektrum_mag(0), frequency(0)
 {
   spektrum = new Vector<std::complex<double>, 3>[spek_length];
@@ -37,9 +37,9 @@ Detector_dft::Detector_dft(R_vec n_unit, double delta_t, const unsigned spek_len
   set_frequency(omega_max); 
 }
 
-Detector_dft::Detector_dft(R_vec n_unit, double delta_t, const unsigned spek_length,
+Detector_dft::Detector_dft(R_vec n_unit,  const unsigned spek_length,
 			   const double* omega)
-  : n_unit(n_unit.unit_vec()), delta_t(delta_t), spek_length(spek_length),
+  : n_unit(n_unit.unit_vec()),  spek_length(spek_length),
     spektrum(0), spektrum_mag(0), frequency(0)
 {
   spektrum = new Vector<std::complex<double>, 3>[spek_length];
@@ -63,7 +63,8 @@ Detector_dft::~Detector_dft()
 void Detector_dft::add_to_spectrum(const R_vec r, 
 				   const R_vec beta,
 				   const R_vec dot_beta,
-				   const double t_part)
+                   const double t_part,
+                   const double delta_t)
 {
   const R_vec fou1a = (n_unit%((n_unit-beta)%dot_beta)) 	
                         / util::square(1. - beta * n_unit);
@@ -89,7 +90,8 @@ void Detector_dft::add_to_spectrum(const R_vec r,
 				   const R_vec beta,
 				   const double gamma,
 				   const double dot_gamma,
-				   const double t_part)
+                   const double t_part,
+                   const double delta_t)
 {		
   const R_vec     p_wave = p/(phy::m_e*phy::c);
   const R_vec dot_p_wave = dot_p/(phy::m_e*phy::c);

--- a/src/include/detector_dft.hpp
+++ b/src/include/detector_dft.hpp
@@ -43,10 +43,10 @@ public:
        @param n_unit   = unit vector in direction of energy deposition
        @param delta_t  = time step of odint
      */
-  Detector_dft(R_vec n_unit, double delta_t, const unsigned spek_length,
+  Detector_dft(R_vec n_unit, const unsigned spek_length,
 	       const double omega_max);
 
-  Detector_dft(R_vec n_unit, double delta_t, const unsigned spek_length,
+  Detector_dft(R_vec n_unit, const unsigned spek_length,
 	       const double* omega);
 
 
@@ -55,7 +55,8 @@ public:
   void add_to_spectrum(const R_vec r_0, 
 		       const R_vec beta_0,
 		       const R_vec dot_beta_0,
-		       const double t_part_0);
+               const double t_part_0,
+               const double delta_t);
 	
   void add_to_spectrum(const R_vec r_0, 
 		       const R_vec p_0, 
@@ -63,7 +64,8 @@ public:
 		       const R_vec beta_0,
 		       const double gamma_0,
 		       const double dot_gamma_0,
-		       const double t_part_0);
+               const double t_part_0,
+               const double delta_t);
 
   void calc_spectrum();
 
@@ -76,7 +78,6 @@ public:
 private:
   // data:		
   const R_vec n_unit;
-  const double delta_t;
   const  unsigned spek_length;
 
 

--- a/src/single_trace.cpp
+++ b/src/single_trace.cpp
@@ -159,7 +159,7 @@ int single_trace(const one_line* data,
 
       /* get frequencies from FFT */
       double* dummy_omega = (*detector_fft[i]).frequency;
-      detector_dft[i] = new Detector_dft((looking_vector[i]), stepwidth, 
+      detector_dft[i] = new Detector_dft((looking_vector[i]), 
                                          dummy_N, dummy_omega);
     }
 


### PR DESCRIPTION
This pull request moves the `delta_t` setting from the constructor of the DFT detector to the `add_to_spectrum` method of the DFT detector. This interface now matches that of the  FFT detector and they can be replaced by each other. 
