### PR TITLE
add Nyquist limiter to DFT detector

### DIFF
--- a/src/include/detector_dft.cpp
+++ b/src/include/detector_dft.cpp
@@ -77,6 +77,8 @@ void Detector_dft::add_to_spectrum(const R_vec r,
 		                  (t_part - (n_unit*r)/phy::c));
       for (unsigned i=0; i<3; ++i)
 	{
+        // this is the (local) Nyquist limiter 
+        if(frequency[a] < 0.75 * M_PI / (delta_t*(1.0 - beta * n_unit)) )
 	  (spektrum[a])[i] += fou1b[i]*fou2*delta_t;
 	}
 
@@ -105,6 +107,8 @@ void Detector_dft::add_to_spectrum(const R_vec r,
 				  (t_part - (n_unit*r)/phy::c));
       for (unsigned i=0; i<3; ++i)
 	{
+        // this is the (local) Nyquist limiter 
+        if(frequency[a] < 0.75 * M_PI / (delta_t*(1.0 - beta * n_unit)) )
 	  (spektrum[a])[i] += fou1_complex[i]*fou2*delta_t;
 	}
 


### PR DESCRIPTION
This pull request adds a Nyquist limiter (similar to [the one in PIConGPU](https://github.com/ComputationalRadiationPhysics/picongpu/blob/b00083f268846f69f501cbeb6aafa9a13c783929/src/picongpu/include/plugins/radiation/nyquist_low_pass.hpp#L37-L55)) to the DFT detector of Clara2.

**Please do not merge before the results of the run time tests.**

_Please do not judge spacing and aligning, this will need a major rework in a followup pull request._ 
