### PR TITLE
make unit vector methode constant

### DIFF
--- a/src/include/detector_dft.cpp
+++ b/src/include/detector_dft.cpp
@@ -25,7 +25,7 @@
 
 // Constructors and Destructors:
 
-Detector_dft::Detector_dft(R_vec n_unit,
+Detector_dft::Detector_dft(const R_vec n_unit,
                            const unsigned spek_length,
                            const double omega_max)
   : n_unit(n_unit.unit_vec()),
@@ -41,7 +41,7 @@ Detector_dft::Detector_dft(R_vec n_unit,
   set_frequency(omega_max);
 }
 
-Detector_dft::Detector_dft(R_vec n_unit,
+Detector_dft::Detector_dft(const R_vec n_unit,
                            const unsigned spek_length,
                            const double* omega)
   : n_unit(n_unit.unit_vec()),

--- a/src/include/detector_dft.hpp
+++ b/src/include/detector_dft.hpp
@@ -40,11 +40,11 @@ public:
        @param n_unit   = unit vector in direction of energy deposition
        @param delta_t  = time step of odint
      */
-  Detector_dft(R_vec n_unit,
+  Detector_dft(const R_vec n_unit,
                const unsigned spek_length,
                const double omega_max);
 
-  Detector_dft(R_vec n_unit,
+  Detector_dft(const R_vec n_unit,
                const unsigned spek_length,
                const double* omega);
 

--- a/src/include/detector_fft.cpp
+++ b/src/include/detector_fft.cpp
@@ -24,8 +24,8 @@
 
 
 // Constructor and Destructor:
-Detector_fft::Detector_fft(R_vec n_unit,
-                           unsigned N_data)
+Detector_fft::Detector_fft(const R_vec n_unit,
+                           const unsigned N_data)
   : n_unit(n_unit.unit_vec()),
     N_data(N_data),
     counter(0),

--- a/src/include/detector_fft.hpp
+++ b/src/include/detector_fft.hpp
@@ -42,7 +42,8 @@ public:
     @param n_unit   = unit vector in direction of energy deposition
     @param delta_t  = time step of odint
   */
-  Detector_fft(R_vec n_unit, unsigned N_data);
+  Detector_fft(const R_vec n_unit, 
+               const unsigned N_data);
 
   ~Detector_fft();
 

--- a/src/include/vector.hpp
+++ b/src/include/vector.hpp
@@ -89,7 +89,7 @@ public:
   /// assign addition
   inline Vector & operator += (const Vector& v);
 
-  inline Vector unit_vec();
+  inline Vector unit_vec() const;
 
 
   ////////////

--- a/src/include/vector.tpp
+++ b/src/include/vector.tpp
@@ -158,7 +158,7 @@ inline Vector<T, N> & Vector<T, N>::operator += (const Vector& v)
 
 
 template< typename T, unsigned N>
-inline Vector<T, N> Vector<T, N>::unit_vec()
+inline Vector<T, N> Vector<T, N>::unit_vec() const
 {
   return *this / mag() ;
 }


### PR DESCRIPTION
This pull request makes the unit vector method constant (which it is but was not declared) and makes the dft interface use a `const n_vec`.

 - [x] compilation successful
 - [x] simulation run successful 