### PR TITLE
move filename setup into setup.hpp

### DIFF
--- a/src/all_directions.cpp
+++ b/src/all_directions.cpp
@@ -18,36 +18,26 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 #include "all_directions.hpp"
-
-
-
 
 #include <iostream>
 #include <string>
 #include <cassert>
 #include <cstdlib>
-
 #include <stdlib.h>
 #include <sys/time.h>
 #include <omp.h>  // OpenMP
 
 #include "single_trace.hpp"
-
 #include "vector.hpp"
 #include "analytical_solution.hpp"
 #include "physics_units.hpp"
 #include "string_manipulation.hpp"
-
-
 #include "import_from_file.hpp"
 #include "load_txt.hpp"
 #include "gzip_lib.hpp"
 #include "settings.hpp"
-
-
+#include "setFilename.hpp"
 
 
 /**
@@ -143,45 +133,26 @@ int all_directions(const unsigned int trace_id,
 
   /* ------- location of data ----------------------- */
 
-  /* TO DO: SIMPLIFY THIS BY USING SPRINTF() */
-  /* set directory where to find the data: */
-  const char directory[] = "/net/cns/projects/HPLsim/xray/debus/ELBEThomson/basicRun2/";
-  /* set name of trajectory file before index appears in file name: */
-  const char prefix[] = "trace_";
-  /* set name of file after index is used */
-  const char postfix[] = ".txt";
-
-  /* join all parts together and store path to file in "filename" */
-  char filename[256];
-  if(sprintf(filename,
-         "%s%s%04d%s",
-         directory,
-         prefix,
-         trace_id,
-         postfix) > 254)
-  {
-    /* throw warning when buffer is to small for path name */
-    std::cerr << "buffer  to small!!! " << std::endl;
-    throw "Buffer to small!";
-  }
+  char filenameTrace[N_char_filename];
+  setFilename(filenameTrace, traceFileTemplate, trace_id, N_char_filename);
   /* print out path name in order to check it in output files */
-  std::cout << "check: filename: " << filename << std::endl;
+  std::cout << "check: filename: " << filenameTrace << std::endl;
 
 
   /* -------- load trace from file ------- */
 
   /* check if given file exists */
-  if(!file_exists(filename))
+  if(!file_exists(filenameTrace))
     return 1;
 
   /* output to inform user that file is loaded */
-  std::cout << "load file: " << filename << std::endl;
+  std::cout << "load file: " << filenameTrace << std::endl;
 
   /* create memory */
-  const unsigned linenumber = linecounter(filename); /* get lines of data */
+  const unsigned linenumber = linecounter(filenameTrace); /* get lines of data */
   one_line* data = new one_line[linenumber]; /* get memory for data */
   /* run function that fills data from file into "data": */
-  load_txt(filename, linenumber, data);
+  load_txt(filenameTrace, linenumber, data);
 
 
 
@@ -211,19 +182,10 @@ int all_directions(const unsigned int trace_id,
 
   /* ------- outputfile ------------------------------ */
   /* allocate memory for name of output file */
-  char outputfilename[256];
-
-  /* fill output file for each trace_id based on template */
-  if(sprintf(outputfilename,
-             "my_spectrum_trace%06d.dat",
-             trace_id) > 254)
-  {
-    std::cerr << "buffer  to small!!! " << std::endl;
-    throw "Buffer to small!";
-  }
+  char outputfilename[N_char_filename];
+  setFilename(outputfilename, outputFileTemplate, trace_id, N_char_filename);
   /* print name of output file */
   std::cout << "check: output-filename: " << outputfilename << std::endl;
-
 
 
   /* --- file output ------------- */

--- a/src/makefile
+++ b/src/makefile
@@ -64,14 +64,14 @@ single_trace.o: single_trace.hpp single_trace.cpp ./include/detector_e_field.hpp
              ./include/interpolation.tpp 
 	$(CC) $(CFLAGS) $(COBJ) $(CFLAGFORTRAN) $(OMP) -I./include/ single_trace.cpp
 
-all_directions.o: all_directions.cpp all_directions.hpp single_trace.hpp ./include/vector.hpp ./include/string_manipulation.hpp settings.hpp
+all_directions.o: all_directions.cpp all_directions.hpp single_trace.hpp ./include/vector.hpp ./include/string_manipulation.hpp settings.hpp setFilename.hpp
 	$(CC) $(CFLAGS) $(COBJ) $(OMP) $(ZIP) -I./include/ all_directions.cpp
 
 
 # How do I include the detector.hpp <-- vector.hpp dependency
 
 
-process: process_data.cpp settings.hpp
+process: process_data.cpp settings.hpp setFilename.hpp
 	$(CC) $(CFLAGS) $(ZIP) process_data.cpp -o process_data
 
 convert_to_matrix: convert_to_matrix.cpp

--- a/src/process_data.cpp
+++ b/src/process_data.cpp
@@ -25,6 +25,7 @@
 #include <sstream>
 #include "gzip_lib.hpp"
 #include "settings.hpp"
+#include "setFilename.hpp"
 
 
 template<typename T, unsigned int N>
@@ -55,8 +56,6 @@ int main(int argc, char * const argv[])
 
   using namespace std;
   const unsigned int N_direction = N_theta*N_phi;
-  const char input_pattern[] = "my_spectrum_trace%06d.dat";
-  const char output_pattern[] = "my_spectrum_all_%03d.dat";
   const unsigned int N_split = 8;
 
   spectrum<double, N_omega>* data = new spectrum<double, N_omega>[N_direction];
@@ -86,8 +85,8 @@ int main(int argc, char * const argv[])
   // ----- run through all input files -------
   for(unsigned int index_files = index_files_first; index_files <= index_files_last; ++index_files)
   {
-    char filename[256];
-    sprintf(filename, input_pattern, index_files);
+    char filename[N_char_filename];
+    setFilename(filename, outputFileTemplate, index_files, N_char_filename);
 
     // ------ read input file ------
     if(ascii_input)
@@ -155,8 +154,9 @@ int main(int argc, char * const argv[])
   std::cout << "store data" << std::endl;
   for(unsigned int index_phi = 0; index_phi < N_phi; ++index_phi)
   {
-    char output_filename[256];
-    sprintf(output_filename, output_pattern, index_phi);
+    char output_filename[N_char_filename];
+    setFilename(output_filename, output_pattern, index_phi, N_char_filename);
+
     std::ofstream output(output_filename);
     if(output.is_open())
     {
@@ -183,8 +183,8 @@ int main(int argc, char * const argv[])
   std::cout << "deleting files" << std::endl;
   for(unsigned int index_files = index_files_first; index_files <= index_files_last; ++index_files)
   {
-    char filename[256];
-    sprintf(filename, input_pattern, index_files);
+    char filename[N_char_filename];
+    setFilename(filename, outputFileTemplate, index_files, N_char_filename);
 
     if(remove(filename) == 0)
       std::cout << "removed: " << filename << std::endl;

--- a/src/setFilename.hpp
+++ b/src/setFilename.hpp
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2016 Richard Pausch
+ *
+ * This file is part of Clara 2.
+ *
+ * Clara 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Clara 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Clara 2.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "settings.hpp"
+
+
+void setFilename(char* filename, 
+                 const char* templateString,
+                 const unsigned int trace_id, 
+                 const unsigned int N_char_filename)
+{
+  if(sprintf(filename,
+             templateString,
+             trace_id)
+     > int(N_char_filename))
+  {
+    /* throw warning when buffer is to small for path name */
+    std::cerr << "filename buffer too small!!! " << std::endl;
+    throw "Buffer to small!";
+  }
+}
+

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 Alexander Koehler
+ * Copyright 2016 Alexander Koehler, Richard Pausch
  *
  * This file is part of Clara 2.
  *
@@ -30,7 +30,12 @@ const unsigned int N_trace             = 2000;    /* maximum number of traces */
 
 const unsigned int fft_length_factor   = 1;
 
+const unsigned int N_char_filename=256; // number of characters
+const char traceFileTemplate[] = "/net/cns/projects/HPLsim/xray/debus/ELBEThomson/basicRun2/trace_%04d.txt";
+const char outputFileTemplate[] = "my_spectrum_trace%06d.dat";
+
 // explicit for process_data
 const unsigned int N_omega             = N_spectrum;
 const unsigned int index_files_first   = 0;
 const unsigned int index_files_last    = N_trace;
+const char output_pattern[] = "my_spectrum_all_%03d.dat";


### PR DESCRIPTION
This pull request moves the input and output file names defined in `all_directions.cpp` and `process_data.cpp` into `settings.hpp`.

It also generalizes the warning of a puffer overflow by introducing a setter function in `setFilename.hpp`.

 - [x] successful compile test
 - [x] successful simulation 