### PR TITLE
move file_exists() to seperate file

### DIFF
--- a/src/convert_to_matrix.cpp
+++ b/src/convert_to_matrix.cpp
@@ -39,21 +39,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <cmath>
-
-
-/** TO DO: this should be in a separate file - ISSUE #15 **/
-
-/**
- * This function checks if a file exists on the hard drive.
- *
- * @param filename string containing the path and filename to be checked
- * @return Returns true if file exists, otherwise false.
- **/
-bool file_exists(const char *filename)
-{
-  std::ifstream infile(filename);
-  return infile;
-}
+#include "include/fileExists.hpp"
 
 
 

--- a/src/include/fileExists.cpp
+++ b/src/include/fileExists.cpp
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2016 Richard Pausch
+ *
+ * This file is part of Clara 2.
+ *
+ * Clara 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Clara 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Clara 2.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "fileExists.hpp"
+
+/**
+ * check whether a file exists or not
+ *
+ * @param filename pointer to array containing file location
+ * @return Returs true if file exists, otherwise false.
+ **/
+bool file_exists(const char *filename)
+{
+  std::ifstream ifile(filename);
+  return ifile;
+}

--- a/src/include/fileExists.hpp
+++ b/src/include/fileExists.hpp
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2016 Richard Pausch
+ *
+ * This file is part of Clara 2.
+ *
+ * Clara 2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Clara 2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Clara 2.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <fstream>
+
+#pragma once
+
+/**
+ * check whether a file exists or not
+ *
+ * @param filename pointer to array containing file location
+ * @return Returs true if file exists, otherwise false.
+ **/
+bool file_exists(const char *filename);

--- a/src/include/makefile
+++ b/src/include/makefile
@@ -23,7 +23,7 @@ CC = g++
 CFLAGS = -Wall -O3 -c
 
 
-all: libDetector.a
+all: libDetector.a fileExists.o
 
 libDetector.a: detector_e_field.o  detector_dft.o detector_fft.o
 	rm -f libDetector.a
@@ -42,6 +42,8 @@ detector_dft.o: detector_dft.cpp detector_dft.hpp vector.hpp utilities.hpp
 detector_fft.o: detector_fft.cpp detector_fft.hpp vector.hpp utilities.hpp fft_ned.hpp ../settings.hpp
 	$(CC) $(CFLAGS) detector_fft.cpp
 
+fileExists.o: fileExists.hpp fileExists.cpp
+	$(CC) $(CFLAGS) fileExists.cpp
 
 # How do I include the detector.hpp <-- vector.hpp dependency
 

--- a/src/makefile
+++ b/src/makefile
@@ -33,22 +33,22 @@ ARRAYFLAG= -D__PARALLEL_SETTING__=2
 MPICC=mpic++
 
 
-CFLAGFORTRAN = #-DCHECK_FOR_FORTRAN_ERROR 
+CFLAGFORTRAN = #-DCHECK_FOR_FORTRAN_ERROR
 # in case one need to check for FORTRAN output errors
 
 
 
 all: subsystem MPI process convert_to_matrix
 
-subsystem: 
+subsystem:
 	$(MAKE) -C ./include/
 
 
 MPI: MPI_main all_directions.o ./include/libDetector.a single_trace.o
-	$(MPICC) $(CFLAGS) $(OMP) $(ZIP) main.o all_directions.o single_trace.o ./include/libDetector.a -o executable
+	$(MPICC) $(CFLAGS) $(OMP) $(ZIP) main.o all_directions.o single_trace.o ./include/libDetector.a ./include/fileExists.o -o executable
 
 ARRAY: ARRAY_main all_directions.o ./include/libDetector.a single_trace.o
-	$(CC) $(CFLAGS) $(OMP) $(ZIP) main.o all_directions.o single_trace.o ./include/libDetector.a -o executable
+	$(CC) $(CFLAGS) $(OMP) $(ZIP) main.o all_directions.o single_trace.o ./include/libDetector.a ./include/fileExists.o -o executable
 
 
 MPI_main: main.cpp all_directions.hpp
@@ -59,9 +59,9 @@ ARRAY_main:  main.cpp all_directions.hpp
 
 # main routine:
 single_trace.o: single_trace.hpp single_trace.cpp ./include/detector_e_field.hpp ./include/detector_dft.hpp \
-             ./include/detector_fft.hpp ./include/vector.hpp ./include/import_from_file.hpp ./include/discrete.hpp \
-             ./run_through_data.hpp ./include/load_txt.hpp ./include/analytical_solution.hpp ./include/interpolation.hpp \
-             ./include/interpolation.tpp 
+			 ./include/detector_fft.hpp ./include/vector.hpp ./include/import_from_file.hpp ./include/discrete.hpp \
+			 ./run_through_data.hpp ./include/load_txt.hpp ./include/analytical_solution.hpp ./include/interpolation.hpp \
+			 ./include/interpolation.tpp ./include/fileExists.hpp ./include/fileExists.cpp
 	$(CC) $(CFLAGS) $(COBJ) $(CFLAGFORTRAN) $(OMP) -I./include/ single_trace.cpp
 
 all_directions.o: all_directions.cpp all_directions.hpp single_trace.hpp ./include/vector.hpp ./include/string_manipulation.hpp settings.hpp
@@ -74,8 +74,8 @@ all_directions.o: all_directions.cpp all_directions.hpp single_trace.hpp ./inclu
 process: process_data.cpp settings.hpp
 	$(CC) $(CFLAGS) $(ZIP) process_data.cpp -o process_data
 
-convert_to_matrix: convert_to_matrix.cpp
-	$(CC) $(CFLAGS) convert_to_matrix.cpp -o convert_to_matrix
+convert_to_matrix: convert_to_matrix.cpp ./include/fileExists.hpp ./include/fileExists.cpp
+	$(CC) $(CFLAGS) convert_to_matrix.cpp ./include/fileExists.o -o convert_to_matrix
 
 clean:
 	rm -f *o

--- a/src/single_trace.cpp
+++ b/src/single_trace.cpp
@@ -174,18 +174,3 @@ int single_trace(const one_line* data,
 
   return 0;
 }
-
-
-
-/* TO DO: this should be in a separate file - ISSUE #15 */
-/**
- * check whether a file exists or not
- *
- * @param filename pointer to array containing file location
- * @return Returs true if file exists, otherwise false.
- **/
-bool file_exists(const char *filename)
-{
-  ifstream ifile(filename);
-  return ifile;
-}

--- a/src/single_trace.hpp
+++ b/src/single_trace.hpp
@@ -36,6 +36,7 @@ using namespace std;
 #include "detector_fft.hpp"
 #include "import_from_file.hpp"
 #include "physics_units.hpp"
+#include "fileExists.hpp"
 
 /* only needed for near field calculation
  * REMOVE ? */
@@ -60,13 +61,3 @@ int single_trace(const one_line* data,
                  const unsigned N_all_spec,
                  const double theta_offset = 0.0,
                  const double phi_offset = 0.0);
-
-
-/* TO DO: this should be in a separate file - ISSUE #15 */
-/**
- * check whether a file exists or not
- *
- * @param filename pointer to array containing file location
- * @return Returs true if file exists, otherwise false.
- **/
-bool file_exists(const char *filename);


### PR DESCRIPTION
This pull request closes issue #15.

The function `file_exists()` which is used by both `single_trace.hpp` and `convert_to_matrix.cpp` and which is implemented twice is now moved to a separate file with own compile process. 

 - [x]  compile test
 - [x] successful simulation 