### PR TITLE
Remove stringbased output format

### DIFF
--- a/src/all_directions.cpp
+++ b/src/all_directions.cpp
@@ -46,12 +46,9 @@
  *
  * @param trace_id a unique id which which the trajectory file
  *                 can be identified
- * @param arg  a string telling whether a "binary" or "ascii"
- *             output should be used
  * @return error code
  **/
-int all_directions(const unsigned int trace_id,
-                   const char arg[])
+int all_directions(const unsigned int trace_id)
 {
 
   using namespace std;
@@ -72,27 +69,6 @@ int all_directions(const unsigned int trace_id,
   {
     std::cout << "trace-ID is out of range (MAX = " << N_trace << ")" << std::endl;
     return 1;
-  }
-
-  /* -------- get store info ----------- */
-  /* since output can be stored as binary file or as ascii file, here the selected option
-   * is checked or an error is thrown in case the selection was wrong */
-  bool ascii_output;
-  std::string store_str = arg;
-  if(!store_str.compare("ascii"))
-  {
-    ascii_output = true;
-    std::cout << "ASCII output" << std::endl;
-  }
-  else if(!store_str.compare("binary"))
-  {
-    ascii_output = false;
-    std::cout << "binary output" << std::endl;
-  }
-  else
-  {
-    std::cerr << "2nd argument needs to be binary or ascii" << std::endl;
-    throw "bin_ascii";
   }
 
 
@@ -191,7 +167,7 @@ int all_directions(const unsigned int trace_id,
   /* --- file output ------------- */
 
   /* store spectral data either as binary or as ascii data */
-  if(ascii_output)
+  if(param::ascii_output)
   {
     /* ---- ASCII output file ------------------------ */
     ofstream my_output(outputfilename); /* create file */

--- a/src/all_directions.hpp
+++ b/src/all_directions.hpp
@@ -26,9 +26,6 @@
  *
  * @param trace_id a unique id which which the trajectory file
  *                  can be identified
- * @param arg  a string telling whether a "binary" or "ascii"
- *              output should be used
  * @return error code
  **/
-int all_directions(const unsigned int trace_id,
-                   const char arg[]);
+int all_directions(const unsigned int trace_id);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,7 +80,7 @@ int main(void)
 
     /* calculate the radiation of a single trajectory for all
      * directions of interest */
-    return_value = all_directions(i, "binary");
+    return_value = all_directions(i);
 
     /* set output back to stdout stderr
      * ISSUE: THIS DOES NOT WORK !!!

--- a/src/process_data.cpp
+++ b/src/process_data.cpp
@@ -46,40 +46,11 @@ struct spectrum
 int main(int argc, char * const argv[])
 {
 
-  if(argc != 2)
-  {
-    std::cout << "wrong usage: needs 1 parameters not " << argc -1 << std::endl;
-    std::cout << "give: encoding" << std::endl;
-    return 1;
-  }
-
-
   using namespace std;
   const unsigned int N_direction = N_theta*N_phi;
   const unsigned int N_split = 8;
 
   spectrum<double, N_omega>* data = new spectrum<double, N_omega>[N_direction];
-
-
-  // -------- get store info -----------
-  bool ascii_input;
-  std::string store_str = argv[1];
-  if(!store_str.compare("ascii"))
-  {
-    ascii_input = true;
-    std::cout << "ASCII input" << std::endl;
-  }
-  else if(!store_str.compare("binary"))
-  {
-    ascii_input = false;
-    std::cout << "binary input" << std::endl;
-  }
-  else
-  {
-    std::cerr << "2nd argument needs to be binary or ascii" << std::endl;
-    throw "bin_ascii";
-  }
-
 
 
   // ----- run through all input files -------
@@ -89,7 +60,7 @@ int main(int argc, char * const argv[])
     setFilename(filename, outputFileTemplate, index_files, N_char_filename);
 
     // ------ read input file ------
-    if(ascii_input)
+    if(param::ascii_output)
     {
       // ---- files loaded have ASCII  format -------
       FILE* pFile = fopen(filename, "r");

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -30,6 +30,8 @@ const unsigned int N_trace             = 2000;    /* maximum number of traces */
 
 const unsigned int fft_length_factor   = 1;
 
+const bool ascii_output = false; /* output spectra as ascii text */
+
 const unsigned int N_char_filename=256; // number of characters
 const char traceFileTemplate[] = "/net/cns/projects/HPLsim/xray/debus/ELBEThomson/basicRun2/trace_%04d.txt";
 const char outputFileTemplate[] = "my_spectrum_trace%06d.dat";


### PR DESCRIPTION
This pull request removes the string based selection between `ascii` and `binary` output by using a new parameter in `settings.hpp`.

- [x] compile test
- [x] run time test
- [x] pull request #60 **merged** (needed for parameter namespace)
- [x] adjust wiki
