### PR TITLE
fix includes

### DIFF
--- a/src/all_directions.cpp
+++ b/src/all_directions.cpp
@@ -20,23 +20,15 @@
 
 #include "all_directions.hpp"
 
-#include <iostream>
-#include <string>
-#include <cassert>
-#include <cstdlib>
-#include <stdlib.h>
+
 #include <sys/time.h>
-#include <omp.h>  // OpenMP
 
 #include "single_direction.hpp"
-#include "vector.hpp"
-#include "physics_units.hpp"
-#include "import_from_file.hpp"
 #include "load_txt.hpp"
 #include "include/input_output.hpp"
 #include "settings.hpp"
 #include "setFilename.hpp"
-
+#include "fileExists.hpp"
 
 /**
  * function that calculates spectra in different directions for

--- a/src/include/detector_dft.cpp
+++ b/src/include/detector_dft.cpp
@@ -22,6 +22,9 @@
 
 #include "detector_dft.hpp"
 
+#include "physics_units.hpp"
+#include "utilities.hpp"
+
 
 // Constructors and Destructors:
 

--- a/src/include/detector_dft.hpp
+++ b/src/include/detector_dft.hpp
@@ -20,16 +20,10 @@
 
 
 
-#include <iostream>
-#include <cassert>
-#include <complex>
-#include <cmath>
+#pragma once
 
 #include "vector.hpp"
-#include "physics_units.hpp"
-#include "utilities.hpp"
 
-#pragma once
 
 /** Detector class that computes the spectra via a
   * (non-equidistat) discrete Fourier transform

--- a/src/include/detector_e_field.cpp
+++ b/src/include/detector_e_field.cpp
@@ -21,6 +21,10 @@
 
 #include "detector_e_field.hpp"
 
+#include "physics_units.hpp"
+#include "utilities.hpp"
+
+
 /** constructor for electric field detector (at position in space)
   *
   * @param detector  = R_vec with observation position

--- a/src/include/detector_e_field.hpp
+++ b/src/include/detector_e_field.hpp
@@ -19,20 +19,10 @@
  */
 
 
-
-
-#include <iostream>
-#include <cassert>
-#include <complex>
-#include <cmath>
+#pragma once
 
 #include "vector.hpp"
 #include "large_index_storage.hpp"
-#include "physics_units.hpp"
-#include "utilities.hpp"
-
-
-#pragma once
 
 
 /** \brief class for a point-like detector storing the electric field (signal) externally */

--- a/src/include/detector_fft.cpp
+++ b/src/include/detector_fft.cpp
@@ -20,7 +20,11 @@
 
 
 #include "detector_fft.hpp"
+
 #include "../settings.hpp"
+#include "physics_units.hpp"
+#include "utilities.hpp"
+#include "fft_ned.hpp"
 
 
 // Constructor and Destructor:

--- a/src/include/detector_fft.hpp
+++ b/src/include/detector_fft.hpp
@@ -19,19 +19,10 @@
  */
 
 
-
-
-#include <iostream>
-#include <cassert>
-#include <complex>
-#include <cmath>
+#pragma once
 
 #include "vector.hpp"
-#include "physics_units.hpp"
-#include "utilities.hpp"
-#include "fft_ned.hpp"
 
-#pragma once
 
 //! \brief class for a point-like detector storing the signal externally
 class Detector_fft

--- a/src/include/discrete.hpp
+++ b/src/include/discrete.hpp
@@ -19,13 +19,10 @@
  */
 
 
-
-
+#pragma once
 
 #include "utilities.hpp"
 #include "physics_units.hpp"
-
-#pragma once
 
 
 /**

--- a/src/include/fft_ned.hpp
+++ b/src/include/fft_ned.hpp
@@ -19,18 +19,9 @@
  */
 
 
-
-
-
-#include <iostream>
-#include <fstream>
-#include <cmath>
-#include <time.h>
-#include <stdio.h>
-#include <complex>
-
-
 #pragma once
+
+
 
 inline unsigned power_of_two(unsigned N)
 {

--- a/src/include/fileExists.cpp
+++ b/src/include/fileExists.cpp
@@ -20,6 +20,9 @@
 
 #include "fileExists.hpp"
 
+#include <fstream>
+
+
 /**
  * check whether a file exists or not
  *

--- a/src/include/fileExists.hpp
+++ b/src/include/fileExists.hpp
@@ -18,9 +18,9 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <fstream>
 
 #pragma once
+
 
 /**
  * check whether a file exists or not

--- a/src/include/import_from_file.hpp
+++ b/src/include/import_from_file.hpp
@@ -19,11 +19,9 @@
  */
 
 
-
-
-#include <fstream>
-
 #pragma once
+
+
 
 //! \brief simple container to store data from the Clara trace
 /*! usage: one_line x[number of data lines]; then x[i].intern_data[0-6] */

--- a/src/include/input_output.hpp
+++ b/src/include/input_output.hpp
@@ -19,11 +19,9 @@
  */
 
 
-
-#include <stdio.h>
-#include <iostream>
-
 #pragma once
+
+#include <iostream>
 
 
 /**

--- a/src/include/interpolation.hpp
+++ b/src/include/interpolation.hpp
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include "detector_fft.hpp"
 
 template <typename X, typename Y>
 void interpolation(const X* x_old,

--- a/src/include/interpolation.tpp
+++ b/src/include/interpolation.tpp
@@ -19,7 +19,6 @@
  */
 
 
-#include "interpolation.hpp"
 
 
 template <typename X, typename Y>

--- a/src/include/large_index_storage.hpp
+++ b/src/include/large_index_storage.hpp
@@ -19,12 +19,9 @@
  */
 
 
-
-
-#include <iostream>
-#include<cassert>
-
 #pragma once
+
+
 
 /**
  * \brief  storage class by Richard

--- a/src/include/large_index_storage.tpp
+++ b/src/include/large_index_storage.tpp
@@ -19,8 +19,6 @@
  */
 
 
-#include "large_index_storage.hpp"
-
 
 template< typename T>
 inline Large_index_storage<T>::Large_index_storage(const unsigned N,

--- a/src/include/load_txt.hpp
+++ b/src/include/load_txt.hpp
@@ -19,13 +19,9 @@
  */
 
 
-
-#include <iostream>
-#include <string>
-
 #pragma once
 
-#include "import_from_file.hpp"
+#include <fstream>
 
 
 using namespace std;

--- a/src/include/vector.hpp
+++ b/src/include/vector.hpp
@@ -19,13 +19,14 @@
  */
 
 
+#pragma once
 
 #include <iostream>
 #include <cmath>
 #include <cassert>
 #include <complex>
 
-#pragma once
+
 
 /**
  * \brief  Vector class by Richard

--- a/src/process_data.cpp
+++ b/src/process_data.cpp
@@ -19,10 +19,7 @@
  */
 
 
-#include <iostream>
-#include <cstdio>
 #include <fstream>
-#include <sstream>
 #include "include/input_output.hpp"
 #include "settings.hpp"
 #include "setFilename.hpp"

--- a/src/run_through_data.hpp
+++ b/src/run_through_data.hpp
@@ -19,16 +19,9 @@
  */
 
 
-
-
-#include <iostream>
-#include <cstdlib>
-
 #pragma once
 
 #include "discrete.hpp"
-#include "import_from_file.hpp"
-#include "physics_units.hpp"
 #include "vector.hpp"
 #include "settings.hpp"
 

--- a/src/single_direction.cpp
+++ b/src/single_direction.cpp
@@ -21,8 +21,17 @@
 
 #include "single_direction.hpp"
 
+
+#include "vector.hpp"
+//#include "detector_e_field.hpp" /* currently not used */
+#include "detector_dft.hpp"
+#include "detector_fft.hpp"
+
+/* only needed for near field calculation
+ * REMOVE ? */
+/* #include"large_index_storage.hpp" */
+
 #include "interpolation.hpp"
-#include "discrete.hpp"
 #include "run_through_data.hpp"
 
 

--- a/src/single_direction.hpp
+++ b/src/single_direction.hpp
@@ -19,28 +19,9 @@
  */
 
 
-
-
-#include <iostream>
-#include <string>
-#include <cassert>
-#include <cstdlib>
-
 #pragma once
 
-using namespace std;
-
-#include "vector.hpp"
-#include "detector_e_field.hpp"
-#include "detector_dft.hpp"
-#include "detector_fft.hpp"
 #include "import_from_file.hpp"
-#include "physics_units.hpp"
-#include "fileExists.hpp"
-
-/* only needed for near field calculation
- * REMOVE ? */
-/* #include"large_index_storage.hpp" */
 
 
 /**


### PR DESCRIPTION
This pull request solves issue #73.

It moves all `#includes` from hpp to cpp files where possible.

The problem remains with `*.hpp/*.tpp` and `*.hpp`-only files (new issue #81)

The codes compiles. 