### PR TITLE
fix wrong pointer names in ned_fft

### DIFF
--- a/src/include/ned_fft.hpp
+++ b/src/include/ned_fft.hpp
@@ -99,7 +99,7 @@ private:
     // for now not, to keep fft independent to allow later
     // use of liFFT
     // https://github.com/ComputationalRadiationPhysics/liFFT
-    fftw_complex *in, *out;
+    fftw_complex *input, *output;
     input = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * N);
     output = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * N);
 


### PR DESCRIPTION
This fixes wrong variable names in `ned_fft.hpp`. 
This fixes (probably) #89.

Thanks to @schluenz for pointing out this solution. 

