### PR TITLE
fix main.cpp include for array jobs

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+#include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
This pull request adds the iostream library to the `main.cpp`. It is not included if the PBS array job configuration is chosen. 