### PR TITLE
remove using namespace std

### DIFF
--- a/src/all_directions.cpp
+++ b/src/all_directions.cpp
@@ -41,9 +41,6 @@
 int all_directions(const unsigned int trace_id)
 {
 
-  using namespace std;
-
-
   /* ------ start time measurement ------------------ */
   struct timeval t1, t2;
   gettimeofday(&t1, NULL);
@@ -160,7 +157,7 @@ int all_directions(const unsigned int trace_id)
   if(param::ascii_output)
   {
     /* ---- ASCII output file ------------------------ */
-    ofstream my_output(outputfilename); /* create file */
+    std::ofstream my_output(outputfilename); /* create file */
     if(my_output.is_open()) /* check if it is open */
     {
       for(unsigned j=0; j<N_direction; ++j) /* for all directions */

--- a/src/include/load_txt.hpp
+++ b/src/include/load_txt.hpp
@@ -24,8 +24,6 @@
 #include <fstream>
 
 
-using namespace std;
-
 
 //! \brief function returning the number of lines of a file
 /*! @param target a 'const char*' containing file location */
@@ -48,9 +46,9 @@ void load_txt( const char target[],
                const unsigned linenumber,
                one_line* data)
 {
-  ifstream file(target); // file to load
+  std::ifstream file(target); // file to load
 
-  string storage; // storage of short strings
+  std::string storage; // storage of short strings
   for (unsigned i=0; !file.eof(); ++i)
   {
     // check for FORTRAN error: 1.234e-123 is stored wrongly as 1.234-123 !

--- a/src/process_data.cpp
+++ b/src/process_data.cpp
@@ -55,8 +55,6 @@ struct spectrum
   */
 int main()
 {
-  using namespace std;
-
   /* compute total number of observation direction */
   const unsigned int N_direction = param::N_theta * param::N_phi;
 


### PR DESCRIPTION
This pull request closes issue #82 by removing all occurrences of `using namespace std` and adjusting the code. 